### PR TITLE
ecs-run-task: Support setting environment variables in containers

### DIFF
--- a/ecs/run-task/README.md
+++ b/ecs/run-task/README.md
@@ -12,6 +12,8 @@ Flags:
       --task-definition=TASK-DEFINITION
                              ECS task definition
       --cluster=CLUSTER      ECS cluster
+      --task-override-json=TASK-OVERRIDE-JSON
+                             Path to a JSON file with the task override to use
       --assume-role-arn=ASSUME-ROLE-ARN
                              Role to assume
       --assume-role-external-id=ASSUME-ROLE-EXTERNAL-ID

--- a/ecs/run-task/main.go
+++ b/ecs/run-task/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -8,8 +11,9 @@ import (
 )
 
 var (
-	taskDefinition = kingpin.Flag("task-definition", "ECS task definition").Required().String()
-	cluster        = kingpin.Flag("cluster", "ECS cluster").Required().String()
+	taskDefinition   = kingpin.Flag("task-definition", "ECS task definition").Required().String()
+	cluster          = kingpin.Flag("cluster", "ECS cluster").Required().String()
+	taskOverrideJSON = kingpin.Flag("task-override-json", "Path to a JSON file with the task override to use").String()
 )
 
 func main() {
@@ -21,10 +25,36 @@ func main() {
 
 	ecsClient := ecs.New(session, conf)
 
+	taskOverrides, overridesErr := resolveTaskOverride(taskOverrideJSON)
+	common.FatalOnError(overridesErr)
+
 	_, err := ecsClient.RunTask(&ecs.RunTaskInput{
 		TaskDefinition: taskDefinition,
 		Cluster:        cluster,
 		Count:          aws.Int64(1),
+		Overrides:      taskOverrides,
 	})
+
 	common.FatalOnError(err)
+}
+
+func resolveTaskOverride(taskOverridesJSON *string) (*ecs.TaskOverride, error) {
+
+	if *taskOverridesJSON == "" {
+		return nil, nil
+	}
+
+	b, err := os.ReadFile(*taskOverridesJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	var taskOverride *ecs.TaskOverride
+	taskOverride = &ecs.TaskOverride{}
+	err = json.Unmarshal(b, taskOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	return taskOverride, nil
 }


### PR DESCRIPTION
This PR adds support for overwriting the ECS container's env variables through command line arguments when running the run-ecs-task.